### PR TITLE
Add Spectral Efficiency input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Questo repository contiene un semplice strumento in Python per l'analisi del lin
 - Modifica la variabile `GROUND_STATIONS` nel file Python per aggiungere nuove stazioni di terra.
 - Adatta la tabella dell'antenna (`ANTENNA_PATTERN_ANGLES` e `ANTENNA_PATTERN_GAINS`) al tuo specifico diagramma.
 - Per cambiare la durata dell'analisi o l'intervallo di campionamento, modifica i parametri all'inizio della funzione `run_analysis`.
+- Imposta il campo "Spectral Efficiency" nel pannello Baseband per ottenere la larghezza di banda del canale desiderata.
 
 ## License
 This project is released under the [MIT License](LICENSE).

--- a/gui.py
+++ b/gui.py
@@ -540,13 +540,15 @@ def update_link_budget_derived(*args):
         bit_rate_mbps = float(bitrate_entry.get())
         roll_off = float(rolloff_entry.get())
         overhead = float(overhead_entry.get())
+        spectral_eff = float(spectral_eff_entry.get())
         info_bit_rate_mbps = bit_rate_mbps / overhead if overhead != 0 else 0
-        channel_bw_mhz = bit_rate_mbps * (1 + roll_off) / 2
+        spectral_eff = spectral_eff if spectral_eff != 0 else 1
+        channel_bw_mhz = bit_rate_mbps * (1 + roll_off) / spectral_eff
         info_bitrate_var.set(f"Info Bit Rate [Mbps]: {info_bit_rate_mbps:.3f}")
-        channel_bw_var.set(f"Channel BW [MHz] (QPSK): {channel_bw_mhz:.3f}")
+        channel_bw_var.set(f"Channel BW [MHz]: {channel_bw_mhz:.3f}")
     except ValueError:
         info_bitrate_var.set("Info Bit Rate [Mbps]: N/A")
-        channel_bw_var.set("Channel BW [MHz] (QPSK): N/A")
+        channel_bw_var.set("Channel BW [MHz]: N/A")
 
 
 # --- GUI Setup ---
@@ -556,7 +558,7 @@ def setup_gui():
     global root, tle1_entry, tle2_entry, date_entry, gs_var, freq_entry
     global LA_entry, r001_entry, d_gs_entry, other_att_entry, eirp_sat_entry
     global gt_gs_entry, CIo_entry, bitrate_entry, rolloff_entry, demod_loss_entry
-    global overhead_entry, atm_label_var, info_bitrate_var, channel_bw_var
+    global overhead_entry, spectral_eff_entry, atm_label_var, info_bitrate_var, channel_bw_var
     global recalc_button, contact_listbox, plot_frame, table_frame
     global start_refresh_button
 
@@ -732,15 +734,20 @@ def setup_gui():
     overhead_entry = ttk.Entry(baseband_frame, width=15)
     overhead_entry.insert(0, "2.29")
     overhead_entry.grid(row=1, column=3, sticky="ew", padx=5, pady=2)
+    ttk.Label(baseband_frame, text="Spectral Efficiency [b/s/Hz]").grid(row=2, column=0, sticky="w", padx=5, pady=2)
+    spectral_eff_entry = ttk.Entry(baseband_frame, width=15)
+    spectral_eff_entry.insert(0, "2")
+    spectral_eff_entry.grid(row=2, column=1, sticky="ew", padx=5, pady=2)
     info_bitrate_var = tk.StringVar(value="Info Bit Rate [Mbps]: N/A")
-    channel_bw_var = tk.StringVar(value="Channel BW [MHz] (QPSK): N/A")
-    ttk.Label(baseband_frame, textvariable=info_bitrate_var).grid(row=2, column=0, columnspan=2, sticky="w", pady=(5, 0), padx=5)
-    ttk.Label(baseband_frame, textvariable=channel_bw_var).grid(row=2, column=2, columnspan=2, sticky="w", padx=5)
+    channel_bw_var = tk.StringVar(value="Channel BW [MHz]: N/A")
+    ttk.Label(baseband_frame, textvariable=info_bitrate_var).grid(row=3, column=0, columnspan=2, sticky="w", pady=(5, 0), padx=5)
+    ttk.Label(baseband_frame, textvariable=channel_bw_var).grid(row=3, column=2, columnspan=2, sticky="w", padx=5)
     baseband_frame.grid_columnconfigure(1, weight=1)
     baseband_frame.grid_columnconfigure(3, weight=1)
     bitrate_entry.bind("<KeyRelease>", update_link_budget_derived)
     rolloff_entry.bind("<KeyRelease>", update_link_budget_derived)
     overhead_entry.bind("<KeyRelease>", update_link_budget_derived)
+    spectral_eff_entry.bind("<KeyRelease>", update_link_budget_derived)
     update_link_budget_derived()
 
     # --- Buttons frame ---


### PR DESCRIPTION
## Summary
- add Spectral Efficiency field to Baseband Parameters
- compute Channel BW using the input spectral efficiency
- update README customization tips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a95a16f488330b9ec47e5e48f1efc